### PR TITLE
Add ECDSA::Group#== and spec

### DIFF
--- a/spec/ecdsa/group_spec.cr
+++ b/spec/ecdsa/group_spec.cr
@@ -212,6 +212,8 @@ describe ECDSA::Group do
         result: false
       }
     ].each do |spec|
+      ECDSA.get_group( spec[:group_name] ).should eq( ECDSA.get_group( spec[:group_name] ) )
+
       verify_spec(spec[:group_name], spec[:message], spec[:s], spec[:r], spec[:public_key_x], spec[:public_key_y], spec[:result])
     end
   end

--- a/src/ecdsa/group.cr
+++ b/src/ecdsa/group.cr
@@ -19,12 +19,12 @@ module ECDSA
 
     def ==( other : ECDSA::Group )
       ( @name == other.name ) &&
-	 ( @p == other.p ) &&
-	 ( @a == other.a ) &&
-	 ( @b == other.b ) &&
-	 ( @gx == other.gx ) &&
-	 ( @gy == other.gy ) &&
-	 ( @n == other.n )
+      ( @p == other.p ) &&
+      ( @a == other.a ) &&
+      ( @b == other.b ) &&
+      ( @gx == other.gx ) &&
+      ( @gy == other.gy ) &&
+      ( @n == other.n )
     end
 
     def g

--- a/src/ecdsa/group.cr
+++ b/src/ecdsa/group.cr
@@ -17,6 +17,16 @@ module ECDSA
                    @n : BigInt)
     end
 
+    def ==( other : ECDSA::Group )
+      ( @name == other.name ) &&
+	 ( @p == other.p ) &&
+	 ( @a == other.a ) &&
+	 ( @b == other.b ) &&
+	 ( @gx == other.gx ) &&
+	 ( @gy == other.gy ) &&
+	 ( @n == other.n )
+    end
+
     def g
       Point.new(self, @gx, @gy)
     end
@@ -96,3 +106,4 @@ module ECDSA
     end
   end
 end
+


### PR DESCRIPTION
This code fixes an issue I ran into when I created a public key manually with `ECDSA::Point.new( group, x, y )` instead of using a key generated from `ECDSA::Group#create_key_pair`. Creating the point manually is required in my case because I am generating the ECC keys in client-side javascript, then verifying on the server.

When I used `ECDSA::get_group( :secp256k1 )` for group when creating the public key point, then tried to verify a signature with that key using a different invocation of `ECDSA::get_group( :secp256k1 )`, I would get a `PointNotInGroup` exception. Comparing the two groups with `#inspect` showed they only differed in the object's memory location. Checking `ECDSA::get_group(:secp256k1) == ECDSA::get_group(:secp256k1)` resulted in false. I found this not intuitive.

This patch includes a comparison function for `ECDSA::Group` that will compare each group parameter against the other group's version and a specification test that verifies this works as expected.